### PR TITLE
Bump x11/libc deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,5 @@ links = "xdo"
 build = "build.rs"
 
 [dependencies]
-x11 = "2.1.0"
-libc = "0.1.10"
+x11 = "2.12.1"
+libc = "0.2.20"


### PR DESCRIPTION
The x11/libc versions specified by this crate are pretty old, and this prevents dependents from using the latest versions. There doesn't seem to be any conflicts with the update.

The `rust-libxdo` crate still compiles just fine after updating its libc dependency.

I would really appreciate if you could publish a "0.11" with this change!

Thanks :smile: 